### PR TITLE
Export extension name and spec version enums

### DIFF
--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -467,6 +467,13 @@ def TestXmlNodes(registry_file):
 
   check_obj_attr(r.platforms['ggp'], Platform, 'protect', 'VK_USE_PLATFORM_GGP')
 
+def TestExtensionEnums(registry_file):
+  r = Registry(registry_file)
+  p = r.platforms['']
+  extname = 'VK_KHR_get_physical_device_properties2'
+  assert extname in p.extensions
+  assert p.extensions[extname].name_enum == 'VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME'
+  assert p.extensions[extname].spec_version_enum == 'VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_SPEC_VERSION'
 
 registry_file = sys.argv[1] if len(sys.argv) > 1 else 'vk.xml'
 TestParser(registry_file)
@@ -477,3 +484,4 @@ TestStructFiltering(registry_file)
 TestPlatforms(registry_file)
 TestLengthExpr(registry_file)
 TestXmlNodes(registry_file)
+TestExtensionEnums(registry_file)

--- a/vkapi/vkapi.py
+++ b/vkapi/vkapi.py
@@ -587,6 +587,13 @@ class Extension:
     self.requires = [x for x in en.get('requires', '').split(',') if x]
     self.specialuse = [x for x in en.get('specialuse', '').split(',') if x]
 
+    # Read extension name and spec version enums.
+    for ee in [t.get('name') for t in en.findall('require/enum[@value]')]:
+      if ee.endswith('_EXTENSION_NAME'):
+        self.name_enum = ee
+      elif ee.endswith('_SPEC_VERSION'):
+        self.spec_version_enum = ee
+
     self.types = [t.get('name') for t in en.findall('require/type')]
     self.commands = [t.get('name') for t in en.findall('require/command')]
     self.xml_node = en


### PR DESCRIPTION
When the exension name ends with a number, sometimes an additional
underscore is added before the numerical characters in extension
name and spec version enums. To avoid hardcoding this information,
this change exposes the name and spec version enums from the registry.